### PR TITLE
Fixed failed unit tests. Improved input buffer creation

### DIFF
--- a/src/BufferedInputStream.cpp
+++ b/src/BufferedInputStream.cpp
@@ -201,7 +201,18 @@ std::unique_ptr<BufferedInputStream> BufferedInputStream::Create(std::istream& s
         if (err) *err = StateError::ZeroBufferSize;
         return nullptr;
     }
-  
+
+    if (bufferSize < 4) { // Buffer must be at least 4 bytes so we can read a full UTF-8 character
+        if (err) *err = StateError::BufferTooSmall;
+        return nullptr;
+    }
+
+    //we can't trust tr/catch to catch huge allocations since ASan would catch them before any new happens
+    if (bufferSize > kMaxBufferSize) {
+        if (err) *err = StateError::OutOfMemory;
+        return nullptr;
+    }
+
     try {
         auto p = std::unique_ptr<BufferedInputStream>(
             new BufferedInputStream(stream, bufferSize));

--- a/src/BufferedInputStream.h
+++ b/src/BufferedInputStream.h
@@ -27,6 +27,7 @@ public:
     enum class StateError {
         None,
         ZeroBufferSize,
+        BufferTooSmall,
         OutOfMemory,
         IoError,
     };
@@ -36,6 +37,7 @@ public:
     static constexpr uint8_t CR = 0x0D;      // \r
     static constexpr uint8_t SPACE = 0x20;   // space
     static constexpr uint8_t TAB = 0x09;     // \t
+    static constexpr std::size_t kMaxBufferSize = (1ull << 28); //256MB buffer cap
 
     static std::unique_ptr<BufferedInputStream> Create(std::istream& stream, size_t bufferSize, StateError* err = nullptr);
     // Delete copy operations


### PR DESCRIPTION
Fixed failed unit tests. Improved input buffer memory management upon creation

-Added internal buffer limits: [4B, 256MB]
-Unit tests fixed based on new `ensureAtLeast` design -added unit testing for new `Create` factory